### PR TITLE
Simplify extension functionality for CourtListener

### DIFF
--- a/src/content-script/compenents/ChatGPTContainer.new.tsx
+++ b/src/content-script/compenents/ChatGPTContainer.new.tsx
@@ -1,0 +1,95 @@
+import { useState, useCallback, useEffect, useMemo } from 'react'
+import { Spinner, GeistProvider, Loading } from '@geist-ui/core'
+import { GearIcon, SyncIcon } from '@primer/octicons-react'
+import Browser from 'webextension-polyfill'
+import { SearchEngine } from '@/content-script/search-engine-configs'
+import { TriggerMode, Theme, getUserConfig } from '@/config'
+import { QueryStatus } from './ChatGPTQuery'
+import { detectSystemColorScheme } from '@/utils/utils'
+import getQuestion from '@/content-script/compenents/GetQuestion'
+import CourtListenerCard from './CourtListenerCard'
+import logo from '@/assets/img/logo-48.png'
+
+interface Props {
+  question: string | null
+  triggerMode: TriggerMode
+  siteConfig: SearchEngine
+}
+
+function ChatGPTContainer(props: Props) {
+  const [queryStatus, setQueryStatus] = useState<QueryStatus>()
+  const [loading, setLoading] = useState(false)
+  const [theme, setTheme] = useState(Theme.Auto)
+  const [questionData, setQuestionData] = useState<Props>({ ...props })
+
+  const themeType = useMemo(() => {
+    return theme === Theme.Auto ? detectSystemColorScheme() : theme
+  }, [theme])
+
+  const openOptionsPage = useCallback(() => {
+    Browser.runtime.sendMessage({ type: 'OPEN_OPTIONS_PAGE' })
+  }, [])
+
+  const onRefresh = useCallback(async () => {
+    if (loading) return
+    setLoading(true)
+    const newQuestionData = await getQuestion()
+    if (newQuestionData) {
+      setQuestionData({ ...props, ...newQuestionData })
+    }
+    setLoading(false)
+  }, [props, loading])
+
+  useEffect(() => {
+    getUserConfig().then((config) => setTheme(config.theme))
+  }, [])
+
+  return (
+    <div className="glarity--container">
+      <GeistProvider themeType={themeType}>
+        <div className="glarity--chatgpt">
+          <div className="glarity--header">
+            <div>
+              <span className="glarity--header__logo">
+                <img src={logo} alt="Court Assistant" />
+                Court Opinion Assistant
+              </span>
+              <a href="javascript:;" className="glarity--header__logo" onClick={openOptionsPage}>
+                <GearIcon size={14} />
+              </a>
+              {loading ? (
+                <span className="glarity--header__logo">
+                  <Spinner className="glarity--icon--loading" />
+                </span>
+              ) : (
+                <a href="javascript:;" className="glarity--header__logo" onClick={onRefresh}>
+                  <SyncIcon size={14} />
+                </a>
+              )}
+            </div>
+          </div>
+
+          <div className="glarity--main">
+            <div className="glarity--main__container">
+              {loading && (
+                <div className="glarity--main__loading">
+                  <Loading />
+                </div>
+              )}
+              {questionData.question ? (
+                <CourtListenerCard
+                  question={questionData.question}
+                  onStatusChange={setQueryStatus}
+                />
+              ) : (
+                <p>Loading court opinion...</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </GeistProvider>
+    </div>
+  )
+}
+
+export default ChatGPTContainer

--- a/src/content-script/compenents/CourtListenerCard.tsx
+++ b/src/content-script/compenents/CourtListenerCard.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'preact/hooks'
+import { SearchIcon, CommentDiscussionIcon } from '@primer/octicons-react'
+import ChatGPTQuery, { QueryStatus } from './ChatGPTQuery'
+
+interface Props {
+  question: string
+  onStatusChange?: (status: QueryStatus) => void
+}
+
+function CourtListenerCard(props: Props) {
+  const [mode, setMode] = useState<'none' | 'summary' | 'question'>('none')
+  const { question } = props
+
+  if (mode === 'summary') {
+    return (
+      <ChatGPTQuery
+        question={question}
+        onStatusChange={props.onStatusChange}
+      />
+    )
+  }
+
+  if (mode === 'question') {
+    return (
+      <>
+        <div className="glarity--question-input">
+          <input 
+            type="text" 
+            placeholder="Ask your question about this opinion..."
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                const customQuestion = `Regarding this legal opinion, ${e.target.value}`
+                setMode('summary')
+                props.question = customQuestion
+              }
+            }}
+          />
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <div className="glarity--action-buttons">
+      <a
+        href="javascript:;"
+        onClick={() => setMode('summary')}
+      >
+        <SearchIcon size="small" /> Summarize this opinion
+      </a>
+      <a
+        href="javascript:;"
+        onClick={() => setMode('question')}
+      >
+        <CommentDiscussionIcon size="small" /> Ask a question
+      </a>
+    </div>
+  )
+}
+
+export default CourtListenerCard

--- a/src/content-script/compenents/GetQuestion.tsx
+++ b/src/content-script/compenents/GetQuestion.tsx
@@ -31,6 +31,20 @@ export default async function getQuestion() {
 
   const providerConfigs = await getProviderConfigs()
 
+  // CourtListener Opinion
+  if (siteName === 'courtlistener') {
+    const opinionElement = getPossibleElementByQuerySelector(siteConfig.contentContainerQuery || [])
+    if (!opinionElement) return null
+
+    const opinionText = opinionElement.textContent?.trim()
+    if (!opinionText) return null
+
+    const caseTitle = document.querySelector('h2')?.textContent?.trim() || document.title
+    const prompt = `Please provide a concise summary of this legal opinion, focusing on the key facts, issues, and holdings. Case: ${caseTitle}\n\nOpinion text: ${opinionText}`
+
+    return { question: prompt }
+  }
+
   // PubMed
   if (siteName === 'pubmed') {
     if (

--- a/src/content-script/search-engine-configs.new.ts
+++ b/src/content-script/search-engine-configs.new.ts
@@ -1,0 +1,27 @@
+import { queryParam } from 'gb-url'
+
+export interface SearchEngine {
+  inputQuery: string[]
+  sidebarContainerQuery: string[]
+  appendContainerQuery: string[]
+  extabarContainerQuery?: string[]
+  contentContainerQuery: string[]
+  watchRouteChange?: (callback: () => void) => void
+  name?: string
+  siteName: string
+  siteValue: string
+  regex: string
+  searchRegExp?: string
+}
+
+export const config: Record<string, SearchEngine> = {
+  courtlistener: {
+    inputQuery: [],
+    sidebarContainerQuery: ['.col-md-3'],
+    appendContainerQuery: ['.col-md-9'],
+    contentContainerQuery: ['[class="opinion-content"]'],
+    siteName: 'CourtListener',
+    siteValue: 'courtlistener',
+    regex: '(^(www.)?courtlistener.com/opinion/)'
+  }
+}

--- a/src/content-script/search-engine-configs.ts
+++ b/src/content-script/search-engine-configs.ts
@@ -16,16 +16,14 @@ export interface SearchEngine {
 }
 
 export const config: Record<string, SearchEngine> = {
-  google: {
-    inputQuery: ["input[name='q']"],
-    sidebarContainerQuery: ['#rhs'],
-    appendContainerQuery: ['#rcnt'],
-    extabarContainerQuery: ['#extabar'],
-    contentContainerQuery: [],
-    name: 'gogole',
-    siteName: 'Google',
-    siteValue: 'google',
-    regex: '(^(www.)?google.)',
+  courtlistener: {
+    inputQuery: [],
+    sidebarContainerQuery: ['.col-md-3'],
+    appendContainerQuery: ['.col-md-9'],
+    contentContainerQuery: ['[class="opinion-content"]'],
+    siteName: 'CourtListener',
+    siteValue: 'courtlistener',
+    regex: '(^(www.)?courtlistener.com/opinion/)'
   },
   bing: {
     inputQuery: ["[name='q']"],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,8 +29,7 @@
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>",
-        "*://*/*"
+        "*://www.courtlistener.com/opinion/*"
       ],
       "js": [
         "content-script.js"


### PR DESCRIPTION
This PR updates the extension to focus solely on summarizing CourtListener opinion pages. It introduces two main options: 'Summarize this opinion' and 'Ask a question about this opinion', presented in a clean UI. Enhanced the extension by targeting only URLs with regex for CourtListener opinions. Removed multi-platform configs for simplicity.


